### PR TITLE
Add configure attribute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
 
       - name: Check codestyle
         run: vendor/bin/ecs check --config=easy-coding-standard.php --no-progress-bar .
-#
-#      - name: Execute unit tests
-#        run: vendor/bin/phpunit --testsuite unit --testdox --colors=always
-#
-#      - name: Execute mutation tests
-#        run: vendor/bin/infection --threads=4 --min-covered-msi=100
+
+      - name: Execute unit tests
+        run: vendor/bin/phpunit --testsuite unit --testdox --colors=always
+
+      - name: Execute mutation tests
+        run: vendor/bin/infection --threads=4 --min-covered-msi=100

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: Install dependencies
         run: composer update --prefer-dist --no-suggest --no-interaction --no-scripts
-#
-#      - name: Run Infection for added and modified files only
-#        run: |
-#          git fetch --depth=1 origin $GITHUB_BASE_REF
-#          php vendor/bin/infection -j2 --git-diff-filter=AM --logger-github
+
+      - name: Run Infection for added and modified files only
+        run: |
+          git fetch --depth=1 origin $GITHUB_BASE_REF
+          php vendor/bin/infection -j2 --git-diff-filter=AM --logger-github

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": "8.0.*||8.1.*",
         "ergebnis/classy": "^1.3",
-        "illuminate/support": "~8.0||~9.0"
+        "illuminate/support": "~8.0||~9.0",
+        "webmozart/assert": "^1.10"
     },
     "require-dev": {
         "phpunit/phpunit": "~9.0",

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,8 @@ php artisan vendor:publish --tag=autowire.config
 
 ## Usage
 
+### Autowiring
+
 Are you tired of binding abstract interfaces to concrete classes all the time?
 
 ```php
@@ -60,7 +62,51 @@ class WorldClass implements HelloInterface
 The Autowire package will crawl through the classes and bind the abstract interface to the concrete class.
 If there already is a binding in the container it will skip the autowiring.
 
-### Configuration
+### Configure
+
+Personally I like injection of dependencies over resolving them using `make()` helpers.
+However, that means writing binding definitions such as:
+
+```php
+$this->app->when($x)->needs($y)->give($z);
+```
+
+Not anymore with the Configure attribute!
+Here is the WorldClass example again:
+
+```php
+namespace App;
+
+use App\Contracts\HelloInterface;
+
+#[Configure(['$message' => 'world'])]
+class WorldClass
+{
+    private $message;
+
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+}
+```
+
+In this example message is a simple string.
+However, it can be a reference to a configuration value or other class too!
+The notations of config and service definitions is the same as used in Symfony. 
+
+```php
+// Will get the value set in config/app.php
+#[Configure(['$message' => '%app.message%'])]
+
+// Will inject an instance of the Message class
+#[Configure(['$message' => '@App\Domain\Message'])]
+
+// When you have multiple constructor arguments
+#[Configure(['$message' => '%app.message%', '$logger' => '@Psr\Log\LoggerInterface'])]
+```
+
+## Configuration
 
 The package's configuration can be found in `config/autowire.php`.
 It should contain the list of directories where Autowire should look for both interfaces and implementations. 

--- a/src/Attribute/Configure.php
+++ b/src/Attribute/Configure.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Configure
+{
+    private array $configs = [];
+
+    private array $services = [];
+
+    private array $definitions = [];
+
+    public function __construct(array $cables)
+    {
+        foreach ($cables as $variable => $value) {
+            $this->parse($variable, $value);
+        }
+    }
+
+    public function getConfigs(): array
+    {
+        return $this->configs;
+    }
+
+    public function getServices(): array
+    {
+        return $this->services;
+    }
+
+    public function getDefinitions(): array
+    {
+        return $this->definitions;
+    }
+
+    private function parse(string $variable, string $value): void
+    {
+        $hasConfig = preg_match("/%(.*)%/", $value, $config);
+
+        if ($hasConfig === 1) {
+            $this->configs[$variable] = $config[1];
+            return;
+        }
+
+        $hasService = preg_match("/@(.*)/", $value, $service);
+
+        if ($hasService === 1) {
+            $this->services[$variable] = $service[1];
+            return;
+        }
+
+        $this->definitions[$variable] = $value;
+    }
+}

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire;
+
+use Webmozart\Assert\Assert;
+
+final class Configuration
+{
+    public string $implementation;
+
+    /** @var ConfigurationValue[] */
+    public array $definitions;
+
+    public function __construct(string $implementation, array $values)
+    {
+        Assert::allIsInstanceOf($values, ConfigurationValue::class);
+        $this->implementation = $implementation;
+        $this->definitions = $values;
+    }
+}

--- a/src/ConfigurationType.php
+++ b/src/ConfigurationType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire;
+
+final class ConfigurationType
+{
+    public const CONFIG = 'config';
+
+    public const SERVICE = 'service';
+
+    public const UNKNOWN = 'unknown';
+}

--- a/src/ConfigurationValue.php
+++ b/src/ConfigurationValue.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire;
+
+final class ConfigurationValue
+{
+    public function __construct(
+        public string $need,
+        public mixed $give,
+        public string $type,
+    ){
+    }
+}

--- a/src/Electrician.php
+++ b/src/Electrician.php
@@ -54,20 +54,18 @@ final class Electrician
 
     public function canAutowire(string $name): bool
     {
-        $reflectionClass = new \ReflectionClass($name);
-        $attributes = $reflectionClass->getAttributes(AutowireAttribute::class);
-
-        if (empty($attributes)) {
-            return false;
-        }
-
-        return true;
+        return $this->classHasAttribute($name, AutowireAttribute::class);
     }
 
     public function canConfigure(string $name): bool
     {
-        $reflectionClass = new \ReflectionClass($name);
-        $attributes = $reflectionClass->getAttributes(ConfigureAttribute::class);
+        return $this->classHasAttribute($name, ConfigureAttribute::class);
+    }
+
+    private function classHasAttribute(string $className, string $attributeName): bool
+    {
+        $reflectionClass = new \ReflectionClass($className);
+        $attributes = $reflectionClass->getAttributes($attributeName);
 
         if (empty($attributes)) {
             return false;

--- a/src/Electrician.php
+++ b/src/Electrician.php
@@ -45,7 +45,7 @@ final class Electrician
             }
 
             foreach ($instance->getDefinitions() as $need => $give) {
-                $configurations[] = new ConfigurationValue($need, $give, ConfigurationType::SERVICE);
+                $configurations[] = new ConfigurationValue($need, $give, ConfigurationType::UNKNOWN);
             }
         }
 

--- a/src/Electrician.php
+++ b/src/Electrician.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace JeroenG\Autowire;
 
-use Ergebnis\Classy\Constructs;
 use JeroenG\Autowire\Attribute\Autowire as AutowireAttribute;
+use JeroenG\Autowire\Attribute\Configure as ConfigureAttribute;
 use JeroenG\Autowire\Exception\FaultyWiringException;
 
 final class Electrician
@@ -22,10 +22,52 @@ final class Electrician
         return new Wire($interface, $implementation);
     }
 
+    public function configure(string $implementation): Configuration
+    {
+        $reflectionClass = new \ReflectionClass($implementation);
+        $attributes = $reflectionClass->getAttributes(ConfigureAttribute::class);
+        $configurations = [];
+
+        if (empty($attributes)) {
+            throw new FaultyWiringException('oops');
+        }
+
+        foreach ($attributes as $attribute) {
+            /** @var ConfigureAttribute $instance */
+            $instance = $attribute->newInstance();
+
+            foreach ($instance->getConfigs() as $need => $give) {
+                $configurations[] = new ConfigurationValue($need, $give, ConfigurationType::CONFIG);
+            }
+
+            foreach ($instance->getServices() as $need => $give) {
+                $configurations[] = new ConfigurationValue($need, $give, ConfigurationType::SERVICE);
+            }
+
+            foreach ($instance->getDefinitions() as $need => $give) {
+                $configurations[] = new ConfigurationValue($need, $give, ConfigurationType::SERVICE);
+            }
+        }
+
+        return new Configuration($implementation, $configurations);
+    }
+
     public function canAutowire(string $name): bool
     {
         $reflectionClass = new \ReflectionClass($name);
         $attributes = $reflectionClass->getAttributes(AutowireAttribute::class);
+
+        if (empty($attributes)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function canConfigure(string $name): bool
+    {
+        $reflectionClass = new \ReflectionClass($name);
+        $attributes = $reflectionClass->getAttributes(ConfigureAttribute::class);
 
         if (empty($attributes)) {
             return false;

--- a/src/Electrician.php
+++ b/src/Electrician.php
@@ -29,7 +29,7 @@ final class Electrician
         $configurations = [];
 
         if (empty($attributes)) {
-            throw new FaultyWiringException('oops');
+            throw FaultyWiringException::classHasNoAttribute($implementation, ConfigureAttribute::class);
         }
 
         foreach ($attributes as $attribute) {

--- a/src/Exception/FaultyWiringException.php
+++ b/src/Exception/FaultyWiringException.php
@@ -10,4 +10,9 @@ final class FaultyWiringException extends \RuntimeException
     {
         return new self("No implementation found for $interface");
     }
+
+    public static function classHasNoAttribute(string $class, string $attribute): self
+    {
+        return new self("No $attribute found in $class");
+    }
 }

--- a/tests/Support/Subject/Domain/Greeting/ClassGreeting.php
+++ b/tests/Support/Subject/Domain/Greeting/ClassGreeting.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting;
+
+use JeroenG\Autowire\Attribute\Configure;
+
+#[Configure(['$greeting' => '@App\Greeting'])]
+class ClassGreeting
+{
+    private $greeting;
+
+    public function __construct($greeting)
+    {
+        $this->greeting = $greeting;
+    }
+
+    public function getGreeting()
+    {
+        return $this->greeting;
+    }
+}

--- a/tests/Support/Subject/Domain/Greeting/ConfigGreeting.php
+++ b/tests/Support/Subject/Domain/Greeting/ConfigGreeting.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting;
+
+use JeroenG\Autowire\Attribute\Configure;
+
+#[Configure(['$greeting' => '%greeting.hi%'])]
+class ConfigGreeting
+{
+    private $greeting;
+
+    public function __construct($greeting)
+    {
+        $this->greeting = $greeting;
+    }
+
+    public function getGreeting()
+    {
+        return $this->greeting;
+    }
+}

--- a/tests/Support/Subject/Domain/Greeting/TextGreeting.php
+++ b/tests/Support/Subject/Domain/Greeting/TextGreeting.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting;
+
+use JeroenG\Autowire\Attribute\Configure;
+
+#[Configure(['$greeting' => 'Good day to you!'])]
+class TextGreeting
+{
+    private $greeting;
+
+    public function __construct($greeting)
+    {
+        $this->greeting = $greeting;
+    }
+
+    public function getGreeting()
+    {
+        return $this->greeting;
+    }
+}

--- a/tests/Support/SubjectDirectory.php
+++ b/tests/Support/SubjectDirectory.php
@@ -11,4 +11,6 @@ final class SubjectDirectory
     public const CONTRACTS = __DIR__.'/Subject/Contracts';
 
     public const DOMAIN = __DIR__.'/Subject/Domain';
+
+    public const GREETINGS = __DIR__.'/Subject/Domain/Greeting';
 }

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Unit;
+
+use JeroenG\Autowire\Configuration;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigurationTest extends TestCase
+{
+    public function test_it_can_only_contain_value_objects(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected an instance of JeroenG\Autowire\ConfigurationValue. Got: boolean');
+
+        new Configuration('foobar', [false]);
+    }
+}

--- a/tests/Unit/CrawlerTest.php
+++ b/tests/Unit/CrawlerTest.php
@@ -7,6 +7,9 @@ namespace JeroenG\Autowire\Tests\Unit;
 use JeroenG\Autowire\Crawler;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodbyeInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\HelloInterface;
+use JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting\ClassGreeting;
+use JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting\ConfigGreeting;
+use JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting\TextGreeting;
 use JeroenG\Autowire\Tests\Support\Subject\Domain\MarsClass;
 use JeroenG\Autowire\Tests\Support\Subject\Domain\WorldClass;
 use JeroenG\Autowire\Tests\Support\SubjectDirectory;
@@ -21,6 +24,9 @@ final class CrawlerTest extends TestCase
         $expected = [
             GoodbyeInterface::class,
             HelloInterface::class,
+            ClassGreeting::class,
+            ConfigGreeting::class,
+            TextGreeting::class,
             MarsClass::class,
             WorldClass::class,
         ];
@@ -31,11 +37,12 @@ final class CrawlerTest extends TestCase
     public function test_it_can_filter(): void
     {
         $crawler = Crawler::in([SubjectDirectory::ALL])
-            ->filter(fn(string $class) => $class !== MarsClass::class);
+            ->filter(fn(string $class) => !str_contains($class, 'Greeting'));
 
         $expected = [
             GoodbyeInterface::class,
             HelloInterface::class,
+            MarsClass::class,
             WorldClass::class,
         ];
 

--- a/tests/Unit/ElectricianTest.php
+++ b/tests/Unit/ElectricianTest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace JeroenG\Autowire\Tests\Unit;
 
+use JeroenG\Autowire\ConfigurationType;
+use JeroenG\Autowire\ConfigurationValue;
 use JeroenG\Autowire\Crawler;
 use JeroenG\Autowire\Electrician;
 use JeroenG\Autowire\Exception\FaultyWiringException;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodbyeInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\HelloInterface;
+use JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting\ClassGreeting;
+use JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting\ConfigGreeting;
+use JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting\TextGreeting;
 use JeroenG\Autowire\Tests\Support\Subject\Domain\WorldClass;
 use JeroenG\Autowire\Tests\Support\SubjectDirectory;
 use PHPUnit\Framework\TestCase;
@@ -22,6 +27,16 @@ final class ElectricianTest extends TestCase
 
         self::assertTrue($electrician->canAutowire(HelloInterface::class));
         self::assertFalse($electrician->canAutowire(GoodbyeInterface::class));
+    }
+
+    public function test_it_can_tell_if_class_has_configure_attribute(): void
+    {
+        $crawler = Crawler::in([SubjectDirectory::ALL]);
+        $electrician = new Electrician($crawler);
+
+        self::assertTrue($electrician->canConfigure(TextGreeting::class));
+        self::assertFalse($electrician->canConfigure(GoodbyeInterface::class));
+        self::assertFalse($electrician->canConfigure(WorldClass::class));
     }
 
     public function test_it_can_connect_implementation(): void
@@ -43,5 +58,54 @@ final class ElectricianTest extends TestCase
         $this->expectException(FaultyWiringException::class);
         $this->expectExceptionMessage('No implementation found for '.GoodbyeInterface::class);
         $electrician->connect(GoodbyeInterface::class);
+    }
+
+    /** @dataProvider configureDataProvider */
+    public function test_it_can_configure_implementation_with_different_values(
+        string $class,
+        string $value,
+        string $type,
+    ): void
+    {
+        $crawler = Crawler::in([SubjectDirectory::GREETINGS]);
+        $electrician = new Electrician($crawler);
+
+        $configuration = $electrician->configure($class);
+
+        $expected = [new ConfigurationValue('$greeting', $value, $type)];
+
+        self::assertEquals($class, $configuration->implementation);
+        self::assertEquals($expected, $configuration->definitions);
+    }
+
+    public static function configureDataProvider(): \Generator
+    {
+        yield 'text' => [
+            TextGreeting::class,
+            'Good day to you!',
+            ConfigurationType::UNKNOWN
+        ];
+
+        yield 'config' => [
+            ConfigGreeting::class,
+            'greeting.hi',
+            ConfigurationType::CONFIG
+        ];
+
+        yield 'class' => [
+            ClassGreeting::class,
+            'App\Greeting',
+            ConfigurationType::SERVICE
+        ];
+    }
+
+    public function test_it_throws_exception_when_implementation_can_not_be_configured(): void
+    {
+        $crawler = Crawler::in([SubjectDirectory::CONTRACTS]);
+        $electrician = new Electrician($crawler);
+
+        $this->expectException(FaultyWiringException::class);
+        $this->expectExceptionMessage('No JeroenG\Autowire\Attribute\Configure found in '.GoodbyeInterface::class);
+        $electrician->configure(GoodbyeInterface::class);
     }
 }


### PR DESCRIPTION
```php
// Will get the value set in config/app.php
#[Configure(['$message' => '%app.message%'])]

// Will inject an instance of the Message class
#[Configure(['$message' => '@App\Domain\Message'])]

// When you have multiple constructor arguments
#[Configure(['$message' => '%app.message%', '$logger' => '@Psr\Log\LoggerInterface'])]
```