### PR TITLE
Allow for extending of Attributes

### DIFF
--- a/src/Attribute/Autowire.php
+++ b/src/Attribute/Autowire.php
@@ -7,6 +7,6 @@ namespace JeroenG\Autowire\Attribute;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Autowire
+class Autowire
 {
 }

--- a/src/Attribute/Configure.php
+++ b/src/Attribute/Configure.php
@@ -7,7 +7,7 @@ namespace JeroenG\Autowire\Attribute;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Configure
+class Configure
 {
     private array $configs = [];
 

--- a/src/Electrician.php
+++ b/src/Electrician.php
@@ -65,7 +65,7 @@ final class Electrician
     private function classHasAttribute(string $className, string $attributeName): bool
     {
         $reflectionClass = new \ReflectionClass($className);
-        $attributes = $reflectionClass->getAttributes($attributeName);
+        $attributes = $reflectionClass->getAttributes($attributeName, \ReflectionAttribute::IS_INSTANCEOF);
 
         if (empty($attributes)) {
             return false;


### PR DESCRIPTION
- feat: removed final keyword from Attributes
- feat: changed Electrician to recognise child Attributes.

This allows extending the base Autowire and Configure attributes while still retaining full functionality.