### PR TITLE
Add option to use custom attribute classes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Add option to use custom attribute classes
 
 ## [1.3.0]
 

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,13 @@ Keep in mind that caching means that it won't crawl all the classes and changes 
 The package's configuration can be found in `config/autowire.php`.
 It should contain the list of directories where Autowire should look for both interfaces and implementations. 
 
+## Custom attributes
+
+It is possible to use custom Attribute classes for either or both the autowiring or configuration functionality:
+- Create a custom attribute class, making sure to implement either `JeroenG\Autowire\Attribute\AutowireInterface` or `JeroenG\Autowire\Attribute\ConfigureInterface`, depending on the attribute you want to replace.
+- Add a `autowire_attribute` or `configure_attribute` setting to the `config/autowire.php` file, containing the fully-namespaced name of your custom attribute class.
+- Use your custom attribute to mark the interface or class you want to autowire or configure.
+
 ## Changelog
 
 Please see the [changelog](changelog.md) for more information on what has changed recently.

--- a/src/Attribute/Autowire.php
+++ b/src/Attribute/Autowire.php
@@ -7,6 +7,6 @@ namespace JeroenG\Autowire\Attribute;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Autowire
+final class Autowire implements AutowireInterface
 {
 }

--- a/src/Attribute/AutowireInterface.php
+++ b/src/Attribute/AutowireInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Attribute;
+
+interface AutowireInterface
+{
+}

--- a/src/Attribute/ConfigureInterface.php
+++ b/src/Attribute/ConfigureInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Attribute;
+
+interface ConfigureInterface
+{
+    /**
+     * @return array<non-empty-string, non-empty-string>
+     */
+    public function getConfigs(): array;
+
+    /**
+     * @return array<non-empty-string, class-string>
+     */
+    public function getServices(): array;
+
+    /**
+     * @return array<non-empty-string, scalar>
+     */
+    public function getDefinitions(): array;
+}

--- a/src/AutowireServiceProvider.php
+++ b/src/AutowireServiceProvider.php
@@ -7,6 +7,8 @@ namespace JeroenG\Autowire;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
+use JeroenG\Autowire\Attribute\Autowire as AutowireAttribute;
+use JeroenG\Autowire\Attribute\Configure as ConfigureAttribute;
 use JeroenG\Autowire\Console\AutowireCacheCommand;
 use JeroenG\Autowire\Console\AutowireClearCommand;
 use JsonException;
@@ -68,7 +70,9 @@ class AutowireServiceProvider extends ServiceProvider
     private function crawlAndLoad(): void
     {
         $crawler = Crawler::in(config('autowire.directories'));
-        $electrician = new Electrician($crawler);
+        $autowireAttribute = config('autowire.autowire_attribute', AutowireAttribute::class);
+        $configureAttribute = config('autowire.configure_attribute', ConfigureAttribute::class);
+        $electrician = new Electrician($crawler, $autowireAttribute, $configureAttribute);
 
         $wires = $crawler->filter(fn(string $name) => $electrician->canAutowire($name))->classNames();
         $configures = $crawler->filter(fn(string $name) => $electrician->canConfigure($name))->classNames();

--- a/tests/Support/Attributes/CustomAutowire.php
+++ b/tests/Support/Attributes/CustomAutowire.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Attributes;
+
+use Attribute;
+use JeroenG\Autowire\Attribute\AutowireInterface;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class CustomAutowire implements AutowireInterface
+{
+}

--- a/tests/Support/Attributes/CustomConfigure.php
+++ b/tests/Support/Attributes/CustomConfigure.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace JeroenG\Autowire\Attribute;
+namespace JeroenG\Autowire\Tests\Support\Attributes;
 
 use Attribute;
+use JeroenG\Autowire\Attribute\ConfigureInterface;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Configure implements ConfigureInterface
+class CustomConfigure implements ConfigureInterface
 {
     private array $configs = [];
 

--- a/tests/Support/Subject/Contracts/HowDoYouDoInterface.php
+++ b/tests/Support/Subject/Contracts/HowDoYouDoInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Subject\Contracts;
+
+use JeroenG\Autowire\Tests\Support\Attributes\CustomAutowire;
+
+#[CustomAutowire]
+interface HowDoYouDoInterface
+{
+    public function howDoYouDo(): string;
+}

--- a/tests/Support/Subject/Domain/Greeting/CustomGreeting.php
+++ b/tests/Support/Subject/Domain/Greeting/CustomGreeting.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting;
+
+use JeroenG\Autowire\Tests\Support\Attributes\CustomConfigure;
+
+#[CustomConfigure(['$greeting' => 'Good day to you!'])]
+class CustomGreeting
+{
+    private $greeting;
+
+    public function __construct($greeting)
+    {
+        $this->greeting = $greeting;
+    }
+
+    public function getGreeting()
+    {
+        return $this->greeting;
+    }
+}

--- a/tests/Support/Subject/Domain/MoonClass.php
+++ b/tests/Support/Subject/Domain/MoonClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Subject\Domain;
+
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\HowDoYouDoInterface;
+
+class MoonClass implements HowDoYouDoInterface
+{
+    public function howDoYouDo(): string
+    {
+        return 'how do you do?';
+    }
+}

--- a/tests/Unit/CrawlerTest.php
+++ b/tests/Unit/CrawlerTest.php
@@ -7,10 +7,13 @@ namespace JeroenG\Autowire\Tests\Unit;
 use JeroenG\Autowire\Crawler;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodbyeInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\HelloInterface;
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\HowDoYouDoInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting\ClassGreeting;
 use JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting\ConfigGreeting;
+use JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting\CustomGreeting;
 use JeroenG\Autowire\Tests\Support\Subject\Domain\Greeting\TextGreeting;
 use JeroenG\Autowire\Tests\Support\Subject\Domain\MarsClass;
+use JeroenG\Autowire\Tests\Support\Subject\Domain\MoonClass;
 use JeroenG\Autowire\Tests\Support\Subject\Domain\WorldClass;
 use JeroenG\Autowire\Tests\Support\SubjectDirectory;
 use PHPUnit\Framework\TestCase;
@@ -24,14 +27,17 @@ final class CrawlerTest extends TestCase
         $expected = [
             GoodbyeInterface::class,
             HelloInterface::class,
+            HowDoYouDoInterface::class,
             ClassGreeting::class,
             ConfigGreeting::class,
+            CustomGreeting::class,
             TextGreeting::class,
             MarsClass::class,
+            MoonClass::class,
             WorldClass::class,
         ];
 
-        self::assertEquals($expected, $crawler->classNames());
+        self::assertEqualsCanonicalizing($expected, $crawler->classNames());
     }
 
     public function test_it_can_filter(): void
@@ -42,10 +48,12 @@ final class CrawlerTest extends TestCase
         $expected = [
             GoodbyeInterface::class,
             HelloInterface::class,
+            HowDoYouDoInterface::class,
             MarsClass::class,
+            MoonClass::class,
             WorldClass::class,
         ];
 
-        self::assertEquals($expected, array_values($crawler->classNames()));
+        self::assertEqualsCanonicalizing($expected, array_values($crawler->classNames()));
     }
 }


### PR DESCRIPTION
- feat: Add option to use custom attribute classes
- test: Add tests for custom attributes
- test: Update CrawlerTest to ignore ordering of classes.
- docs: Update readme

This change allows users to create custom attribute classes, implementing the interface supplied by the package, and use those to mark their interfaces and/or classes.
