### PR TITLE
Fix codestyle issue and changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [1.4.0]
 - Add option to use custom attribute classes
 
 ## [1.3.0]

--- a/src/Electrician.php
+++ b/src/Electrician.php
@@ -62,13 +62,6 @@ final class Electrician
 
         return new Configuration($implementation, $configurations);
     }
-    
-    private static function assertValidAttributeImplementation(string $className, string $attributeInterface): void
-    {
-        Assert::classExists($className);
-        Assert::notEmpty((new \ReflectionClass($className))->getAttributes(\Attribute::class));
-        Assert::isAOf($className, $attributeInterface, "{$className} : {$attributeInterface}");
-    }
 
     public function canAutowire(string $name): bool
     {
@@ -78,6 +71,13 @@ final class Electrician
     public function canConfigure(string $name): bool
     {
         return $this->classHasAttribute($name, $this->configureAttribute);
+    }
+    
+    private static function assertValidAttributeImplementation(string $className, string $attributeInterface): void
+    {
+        Assert::classExists($className);
+        Assert::notEmpty((new \ReflectionClass($className))->getAttributes(\Attribute::class));
+        Assert::isAOf($className, $attributeInterface, "{$className} : {$attributeInterface}");
     }
 
     private function classHasAttribute(string $className, string $attributeName): bool


### PR DESCRIPTION
style: move private method to correct position
docs: moved new feature to 1.4.0 header in changelog

With this, it should be safe to publish and release a new '1.4.0' tag to trigger Packagist.

Thanks!