### PR TITLE
fix: Make caching work with custom attributes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.4.1]
+- Custom attributes now work with caching
+
 ## [1.4.0]
 - Add option to use custom attribute classes
 

--- a/src/Console/AutowireCacheCommand.php
+++ b/src/Console/AutowireCacheCommand.php
@@ -5,6 +5,8 @@ namespace JeroenG\Autowire\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\File;
+use JeroenG\Autowire\Attribute\Autowire as AutowireAttribute;
+use JeroenG\Autowire\Attribute\Configure as ConfigureAttribute;
 use JeroenG\Autowire\Crawler;
 use JeroenG\Autowire\Electrician;
 
@@ -17,7 +19,9 @@ class AutowireCacheCommand extends Command
     public function handle(): int
     {
         $crawler = Crawler::in(config('autowire.directories'));
-        $electrician = new Electrician($crawler);
+        $autowireAttribute = config('autowire.autowire_attribute', AutowireAttribute::class);
+        $configureAttribute = config('autowire.configure_attribute', ConfigureAttribute::class);
+        $electrician = new Electrician($crawler, $autowireAttribute, $configureAttribute);
 
         $autowires = $crawler->filter(fn(string $name) => $electrician->canAutowire($name))->classNames();
         $configures = $crawler->filter(fn(string $name) => $electrician->canConfigure($name))->classNames();

--- a/src/Console/AutowireClearCommand.php
+++ b/src/Console/AutowireClearCommand.php
@@ -5,8 +5,6 @@ namespace JeroenG\Autowire\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\File;
-use JeroenG\Autowire\Crawler;
-use JeroenG\Autowire\Electrician;
 
 class AutowireClearCommand extends Command
 {


### PR DESCRIPTION
When I added the custom attributes, I overlooked the fact that cache command does its own initialization of the Electrician, so it won't load the correct attributes. 

This commit should fix that.

PS: I had a quick look at adding tests for the console commands, but since the package doesn't load a complete Laravel installation, testing Artisan commands is tricky. So for now, I'm afraid this is it.