### PR TITLE
Feature: attribute to automatically tag implementations of interface

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.6]
+- New `Autotag` attribute for automatically tagging implementations of an interface
+
 ## [1.5]
 - New `Listen` attribute for autowiring events to event listeners
 

--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,10 @@
                 "JeroenG\\Autowire\\AutowireServiceProvider"
             ]
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,50 @@ class WorldClass implements HelloInterface
 The Autowire package will crawl through the classes and bind the abstract interface to the concrete class.
 If there already is a binding in the container it will skip the autowiring.
 
+### Tagging
+
+If you quickly want to tag all implementations of an interface, simply add the `Autotag` attribute to the interface:
+
+```php
+namespace App\Contracts;
+
+use JeroenG\Autowire\Attribute\Autotag;
+
+#[Autotag('myTag')]
+interface HelloInterface
+{
+    public function hello(): string;
+}
+```
+
+All implementations will now be available under the 'myTag' tag:
+
+```php
+$this->app->when(Greeting::class)
+	->needs(HelloInterface::class)
+	->giveTagged('myTag');
+```
+
+If no tag value is specified in the attribute, the fully-namespaced name of the class will be used as the tag:
+
+```php
+namespace App\Contracts;
+
+use JeroenG\Autowire\Attribute\Autotag;
+
+#[Autotag]
+interface GoodbyeInterface
+{
+    public function goodbye(): string;
+}
+```
+
+```php
+$this->app->when(Greeting::class)
+	->needs(GoodbyeInterface::class)
+	->giveTagged(GoodbyeInterface::class);
+```
+
 ### Configure
 
 Personally I like injection of dependencies over resolving them using `make()` helpers.

--- a/src/Attribute/Autotag.php
+++ b/src/Attribute/Autotag.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Attribute;
+
+use Attribute;
+use ReflectionClass;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Autotag implements AutotagInterface
+{
+    public function __construct(
+        private string $tag = '',
+    ) {
+    }
+    
+    public function getTag(ReflectionClass $targetInterface): string
+    {
+        return $this->tag ?: $targetInterface->getName();
+    }
+}

--- a/src/Attribute/AutotagInterface.php
+++ b/src/Attribute/AutotagInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Attribute;
+
+use ReflectionClass;
+
+interface AutotagInterface
+{
+    public function getTag(ReflectionClass $targetInterface): string;
+}

--- a/src/AutowireServiceProvider.php
+++ b/src/AutowireServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
+use JeroenG\Autowire\Attribute\Autotag as AutotagAttribute;
 use JeroenG\Autowire\Attribute\Autowire as AutowireAttribute;
 use JeroenG\Autowire\Attribute\Configure as ConfigureAttribute;
 use JeroenG\Autowire\Attribute\Listen as ListenAttribute;

--- a/src/AutowireServiceProvider.php
+++ b/src/AutowireServiceProvider.php
@@ -13,6 +13,7 @@ use JeroenG\Autowire\Attribute\Configure as ConfigureAttribute;
 use JeroenG\Autowire\Attribute\Listen as ListenAttribute;
 use JeroenG\Autowire\Console\AutowireCacheCommand;
 use JeroenG\Autowire\Console\AutowireClearCommand;
+use JeroenG\Autowire\TaggedInterface;
 use JsonException;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
@@ -54,6 +55,7 @@ class AutowireServiceProvider extends ServiceProvider
         $autowireCache = $cache['autowire'] ?? [];
         $listenCache = $cache['listen'] ?? [];
         $configureCache = $cache['configure'] ?? [];
+        $autotagCache = $cache['autotag'] ?? [];
 
         foreach ($autowireCache as $interface => $implementation) {
             $this->app->bindIf($interface, $implementation);
@@ -72,6 +74,8 @@ class AutowireServiceProvider extends ServiceProvider
 
             $this->define($implementation, $definition);
         }
+        
+        array_walk($autotagCache, function (TaggedInterface $taggedInterface): void {$this->app->tag($taggedInterface->implementations, $taggedInterface->tag);});
     }
 
     private function crawlAndLoad(): void
@@ -80,11 +84,13 @@ class AutowireServiceProvider extends ServiceProvider
         $autowireAttribute = config('autowire.autowire_attribute', AutowireAttribute::class);
         $configureAttribute = config('autowire.configure_attribute', ConfigureAttribute::class);
         $listenAttribute = config('autowire.listen_attribute', ListenAttribute::class);
-        $electrician = new Electrician($crawler, $autowireAttribute, $configureAttribute, $listenAttribute,);
+        $autotagAttribute = config('autowire.autotag_attribute', AutotagAttribute::class);
+        $electrician = new Electrician($crawler, $autowireAttribute, $configureAttribute, $listenAttribute, $autotagAttribute,);
 
         $wires = $crawler->filter(fn (string $name) => $electrician->canAutowire($name))->classNames();
         $listeners = $crawler->filter(fn (string $name) => $electrician->canListen($name))->classNames();
         $configures = $crawler->filter(fn (string $name) => $electrician->canConfigure($name))->classNames();
+        $taggables = $crawler->filter(fn (string $name) => $electrician->canAutotag($name))->classNames();
 
         foreach ($wires as $interface) {
             $wire = $electrician->connect($interface);
@@ -104,6 +110,14 @@ class AutowireServiceProvider extends ServiceProvider
                 $this->define($implementation, $definition);
             }
         }
+        
+        array_walk(
+            $taggables,
+            function (string $interface) use ($electrician): void {
+                $taggedInterface = $electrician->tag($interface);
+                $this->app->tag($taggedInterface->implementations, $taggedInterface->tag);
+            },
+        );
     }
 
     private function define(string $implementation, ConfigurationValue $definition): void

--- a/src/Console/AutowireCacheCommand.php
+++ b/src/Console/AutowireCacheCommand.php
@@ -24,7 +24,8 @@ class AutowireCacheCommand extends Command
         $autowireAttribute = config('autowire.autowire_attribute', AutowireAttribute::class);
         $configureAttribute = config('autowire.configure_attribute', ConfigureAttribute::class);
         $listenAttribute = config('autowire.listen_attribute', ListenAttribute::class);
-        $electrician = new Electrician($crawler, $autowireAttribute, $configureAttribute, $listenAttribute);
+        $autotagAttribute = config('autowire.autotag_attribute', AutotagAttribute::class);
+        $electrician = new Electrician($crawler, $autowireAttribute, $configureAttribute, $listenAttribute, $autotagAttribute);
 
         $autowires = $crawler->filter(fn(string $name) => $electrician->canAutowire($name))->classNames();
         $listeners = $crawler->filter(fn(string $name) => $electrician->canListen($name))->classNames();
@@ -56,7 +57,7 @@ class AutowireCacheCommand extends Command
             }
         }
         
-        $autotagCache = array_map(fn (string $interface): TaggedInterface => $electrician->tag($interface), $taggables);
+        $autotagCache = array_values(array_map(fn (string $interface): TaggedInterface => $electrician->tag($interface), $taggables));
 
         $cache = [
             'autowire' => $autowireCache,

--- a/src/Console/AutowireCacheCommand.php
+++ b/src/Console/AutowireCacheCommand.php
@@ -10,6 +10,7 @@ use JeroenG\Autowire\Attribute\Configure as ConfigureAttribute;
 use JeroenG\Autowire\Attribute\Listen as ListenAttribute;
 use JeroenG\Autowire\Crawler;
 use JeroenG\Autowire\Electrician;
+use JeroenG\Autowire\TaggedInterface;
 
 class AutowireCacheCommand extends Command
 {
@@ -28,6 +29,8 @@ class AutowireCacheCommand extends Command
         $autowires = $crawler->filter(fn(string $name) => $electrician->canAutowire($name))->classNames();
         $listeners = $crawler->filter(fn(string $name) => $electrician->canListen($name))->classNames();
         $configures = $crawler->filter(fn(string $name) => $electrician->canConfigure($name))->classNames();
+        $taggables = $crawler->filter(fn (string $name) => $electrician->canAutotag($name))->classNames();
+        
         $autowireCache = [];
         $listenCache = [];
         $configureCache = [];
@@ -52,11 +55,14 @@ class AutowireCacheCommand extends Command
                 ];
             }
         }
+        
+        $autotagCache = array_map(fn (string $interface): TaggedInterface => $electrician->tag($interface), $taggables);
 
         $cache = [
             'autowire' => $autowireCache,
             'listen' => $listenCache,
             'configure' => $configureCache,
+            'autotag' => $autotagCache,
         ];
 
         File::put(

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -12,6 +12,7 @@ final class Crawler
     private function __construct(
         private array $names
     ) {
+        $this->names = array_values($this->names);
     }
 
     public static function in(array $directories): Crawler

--- a/src/Electrician.php
+++ b/src/Electrician.php
@@ -188,6 +188,6 @@ final class Electrician
     {
         return $this->crawler
             ->filter(fn (string $className): bool => is_subclass_of($className, $interface))
-            ->classNames();            
+            ->classNames();
     }
 }

--- a/src/Electrician.php
+++ b/src/Electrician.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace JeroenG\Autowire;
 
 use Attribute;
+use JeroenG\Autowire\Attribute\Autotag as AutotagAttribute;
 use JeroenG\Autowire\Attribute\Autowire as AutowireAttribute;
+use JeroenG\Autowire\Attribute\AutotagInterface as AutotagAttributeInterface;
 use JeroenG\Autowire\Attribute\AutowireInterface as AutowireAttributeInterface;
 use JeroenG\Autowire\Attribute\Listen;
 use JeroenG\Autowire\Attribute\Listen as ListenAttribute;
@@ -29,11 +31,13 @@ final class Electrician
         private string $autowireAttribute = AutowireAttribute::class,
         private string $configureAttribute = ConfigureAttribute::class,
         private string $listenAttribute = ListenAttribute::class,
+        private string $autotagAttribute = AutotagAttribute::class,
     )
     {
         self::checkValidAttributeImplementation($this->autowireAttribute, AutowireAttributeInterface::class);
         self::checkValidAttributeImplementation($this->configureAttribute, ConfigureAttributeInterface::class);
         self::checkValidAttributeImplementation($this->listenAttribute, ListenAttributeInterface::class);
+        self::checkValidAttributeImplementation($this->autotagAttribute, AutotagAttributeInterface::class);
     }
 
     public function connect(string $interface): Wire
@@ -55,7 +59,7 @@ final class Electrician
         $configurations = [];
 
         foreach ($attributes as $attribute) {
-            /** @var ConfigureAttribute $instance */
+            /** @var ConfigureAttributeInterface $instance */
             $instance = $attribute->newInstance();
 
             foreach ($instance->getConfigs() as $need => $give) {
@@ -86,7 +90,7 @@ final class Electrician
         $events = [];
 
         foreach ($attributes as $attribute) {
-            /** @var ListenAttribute $instance */
+            /** @var ListenAttributeInterface $instance */
             $instance = $attribute->newInstance();
 
             $events[] = $instance->event;
@@ -94,10 +98,36 @@ final class Electrician
 
         return $events;
     }
+    
+    /**
+     * @param class-string $interface
+     */
+    public function tag(string $autotagInterface): TaggedInterface
+    {
+        $reflectionClass = new ReflectionClass($autotagInterface);
+        
+        $attributes = $reflectionClass->getAttributes($this->autotagAttribute);
+
+        if (empty($attributes)) {
+            throw FaultyWiringException::classHasNoAttribute($autotagInterface, $this->autotagAttribute);
+        }
+        
+        $attribute = $attributes[0];
+        
+        /** @var AutotagAttributeInterface $instance */
+        $instance = $attribute->newInstance();
+        
+        return new TaggedInterface($instance->getTag($reflectionClass), $this->findAllImplementations($autotagInterface));
+    }
 
     public function canAutowire(string $name): bool
     {
         return $this->classHasAttribute($name, $this->autowireAttribute);
+    }
+
+    public function canAutotag(string $name): bool
+    {
+        return $this->classHasAttribute($name, $this->autotagAttribute);
     }
 
     public function canListen(string $name): bool
@@ -148,5 +178,16 @@ final class Electrician
         }
 
         throw FaultyWiringException::implementationNotFoundFor($interface);
+    }
+
+    /**
+     * @param class-string $interface
+     * @return list<class-string>
+     */
+    private function findAllImplementations(string $interface): array
+    {
+        return $this->crawler
+            ->filter(fn (string $className): bool => is_subclass_of($className, $interface))
+            ->classNames();            
     }
 }

--- a/src/TaggedInterface.php
+++ b/src/TaggedInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire;
+
+use Webmozart\Assert\Assert;
+
+final class TaggedInterface
+{
+    /** @var non-empty-string */
+    public string $tag;
+
+    /** @var list<class-string> */
+    public array $implementations;
+
+    public function __construct(string $tag, array $implementations)
+    {
+        Assert::notEmpty($tag, 'Tag may not be empty');
+        Assert::allClassExists($implementations, 'Implementations must be valid classes');
+        
+        $this->tag = $tag;
+        $this->implementations = $implementations;
+    }
+    
+    public static function __set_state(array $properties): self
+    {
+        Assert::keyExists($properties, 'tag', 'Invalid export');
+        Assert::keyExists($properties, 'implementations', 'Invalid export');
+        
+        return new self($properties['tag'], $properties['implementations']);
+    }
+}

--- a/tests/Support/Attributes/CustomAutotag.php
+++ b/tests/Support/Attributes/CustomAutotag.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Attributes;
+
+use Attribute;
+use JeroenG\Autowire\Attribute\AutotagInterface;
+use ReflectionClass;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class CustomAutotag implements AutotagInterface
+{
+    public function getTag(ReflectionClass $targetInterface): string
+    {
+        return $targetInterface->getName();
+    }
+}

--- a/tests/Support/Subject/Contracts/GoodafternoonInterface.php
+++ b/tests/Support/Subject/Contracts/GoodafternoonInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Subject\Contracts;
+
+use JeroenG\Autowire\Attribute\Autotag;
+
+#[Autotag]
+interface GoodafternoonInterface
+{
+    public function goodafternoon(): string;
+}

--- a/tests/Support/Subject/Contracts/GoodeveningInterface.php
+++ b/tests/Support/Subject/Contracts/GoodeveningInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Subject\Contracts;
+
+use JeroenG\Autowire\Attribute\Autotag;
+
+#[Autotag('evening')]
+interface GoodeveningInterface
+{
+    public function goodevening(): string;
+}

--- a/tests/Support/Subject/Contracts/GoodmorningInterface.php
+++ b/tests/Support/Subject/Contracts/GoodmorningInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Subject\Contracts;
+
+use JeroenG\Autowire\Tests\Support\Attributes\CustomAutotag;
+
+#[CustomAutotag]
+interface GoodmorningInterface
+{
+    public function goodmorning(): string;
+}

--- a/tests/Support/Subject/Domain/MarsClass.php
+++ b/tests/Support/Subject/Domain/MarsClass.php
@@ -4,8 +4,23 @@ declare(strict_types=1);
 
 namespace JeroenG\Autowire\Tests\Support\Subject\Domain;
 
-class MarsClass
-{
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodeveningInterface;
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodmorningInterface;
+
+class MarsClass implements 
+    GoodeveningInterface,
+    GoodmorningInterface
+{        
+    public function goodevening(): string
+    {
+        return 'good evening';
+    }
+    
+    public function goodmorning(): string
+    {
+        return 'good morning';
+    }
+    
     public function hello(): string
     {
         return 'mars';

--- a/tests/Support/Subject/Domain/MoonClass.php
+++ b/tests/Support/Subject/Domain/MoonClass.php
@@ -4,10 +4,25 @@ declare(strict_types=1);
 
 namespace JeroenG\Autowire\Tests\Support\Subject\Domain;
 
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodafternoonInterface;
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodmorningInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\HowDoYouDoInterface;
 
-class MoonClass implements HowDoYouDoInterface
+class MoonClass implements
+    GoodafternoonInterface, 
+    GoodmorningInterface, 
+    HowDoYouDoInterface
 {
+    public function goodafternoon(): string
+    {
+        return 'good afternoon';
+    }
+    
+    public function goodmorning(): string
+    {
+        return 'good morning';
+    }
+    
     public function howDoYouDo(): string
     {
         return 'how do you do?';

--- a/tests/Support/Subject/Domain/WorldClass.php
+++ b/tests/Support/Subject/Domain/WorldClass.php
@@ -4,10 +4,25 @@ declare(strict_types=1);
 
 namespace JeroenG\Autowire\Tests\Support\Subject\Domain;
 
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodafternoonInterface;
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodeveningInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\HelloInterface;
 
-class WorldClass implements HelloInterface
+class WorldClass implements 
+    GoodafternoonInterface, 
+    GoodeveningInterface, 
+    HelloInterface
 {
+    public function goodafternoon(): string
+    {
+        return 'good afternoon';
+    }
+    
+    public function goodevening(): string
+    {
+        return 'good evening';
+    }
+    
     public function hello(): string
     {
         return 'world';

--- a/tests/Unit/CrawlerTest.php
+++ b/tests/Unit/CrawlerTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace JeroenG\Autowire\Tests\Unit;
 
 use JeroenG\Autowire\Crawler;
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodafternoonInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodbyeInterface;
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodeveningInterface;
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodmorningInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\HelloInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\HowDoYouDoInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Domain\CustomListener;
@@ -26,7 +29,10 @@ final class CrawlerTest extends TestCase
         $crawler = Crawler::in([SubjectDirectory::ALL]);
 
         $expected = [
+            GoodafternoonInterface::class,
             GoodbyeInterface::class,
+            GoodeveningInterface::class,
+            GoodmorningInterface::class,
             HelloInterface::class,
             HowDoYouDoInterface::class,
             CustomListener::class,
@@ -48,7 +54,10 @@ final class CrawlerTest extends TestCase
             ->filter(fn(string $class) => !str_contains($class, 'Greeting'));
 
         $expected = [
+            GoodafternoonInterface::class,
             GoodbyeInterface::class,
+            GoodeveningInterface::class,
+            GoodmorningInterface::class,
             HelloInterface::class,
             HowDoYouDoInterface::class,
             CustomListener::class,

--- a/tests/Unit/CrawlerTest.php
+++ b/tests/Unit/CrawlerTest.php
@@ -66,6 +66,33 @@ final class CrawlerTest extends TestCase
             WorldClass::class,
         ];
 
-        self::assertEqualsCanonicalizing($expected, array_values($crawler->classNames()));
+        self::assertEqualsCanonicalizing($expected, $crawler->classNames());
+    }
+    
+    public function test_classnames_are_returned_as_list(): void
+    {
+        $crawler = Crawler::in([SubjectDirectory::ALL])
+            ->filter(fn(string $class) => !str_contains($class, 'Greeting'));
+
+        self::assertIsList($crawler->classNames());
+    }
+    
+    public static function assertIsList($actual, $message = ''): void
+    {
+        if (function_exists("array_is_list")) {
+            self::assertTrue(array_is_list($actual), $message);
+        } else {
+            $isList = true;
+            $i = 0;
+            
+            foreach ($actual as $key => $_value) {
+                if ($key !== $i++) {
+                    $isList = false;
+                    break;
+                }
+            }
+            
+            self::assertTrue($isList, $message);
+        }
     }
 }

--- a/tests/Unit/ElectricianTest.php
+++ b/tests/Unit/ElectricianTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JeroenG\Autowire\Tests\Unit;
 
 use Generator;
+use JeroenG\Autowire\Attribute\Autotag;
 use JeroenG\Autowire\Attribute\Autowire;
 use JeroenG\Autowire\Attribute\Configure;
 use JeroenG\Autowire\Attribute\Listen;
@@ -14,13 +15,17 @@ use JeroenG\Autowire\Crawler;
 use JeroenG\Autowire\Electrician;
 use JeroenG\Autowire\Exception\FaultyWiringException;
 use JeroenG\Autowire\Exception\InvalidAttributeException;
+use JeroenG\Autowire\Tests\Support\Attributes\CustomAutotag;
 use JeroenG\Autowire\Tests\Support\Attributes\CustomAutowire;
 use JeroenG\Autowire\Tests\Support\Attributes\CustomConfigure;
 use JeroenG\Autowire\Tests\Support\Attributes\CustomListen;
 use JeroenG\Autowire\Tests\Support\Attributes\EmptyClass;
 use JeroenG\Autowire\Tests\Support\Attributes\NotAnAttribute;
 use JeroenG\Autowire\Tests\Support\Attributes\WrongAttribute;
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodafternoonInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodbyeInterface;
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodeveningInterface;
+use JeroenG\Autowire\Tests\Support\Subject\Contracts\GoodmorningInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\HelloInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Contracts\HowDoYouDoInterface;
 use JeroenG\Autowire\Tests\Support\Subject\Domain\CustomListener;
@@ -53,6 +58,37 @@ final class ElectricianTest extends TestCase
         self::assertTrue($electrician->canConfigure(TextGreeting::class));
         self::assertFalse($electrician->canConfigure(GoodbyeInterface::class));
         self::assertFalse($electrician->canConfigure(WorldClass::class));
+    }
+
+    public function test_it_can_tell_if_class_has_autotag_attribute(): void
+    {
+        $crawler = Crawler::in([SubjectDirectory::ALL]);
+        $electrician = new Electrician($crawler);
+
+        self::assertTrue($electrician->canAutotag(GoodafternoonInterface::class));
+        self::assertFalse($electrician->canAutotag(GoodbyeInterface::class));
+    }
+
+    public function test_it_can_tag_implementations(): void
+    {
+        $crawler = Crawler::in([SubjectDirectory::ALL]);
+        $electrician = new Electrician($crawler);
+
+        $taggedInterface = $electrician->tag(GoodafternoonInterface::class);
+
+        self::assertEquals(GoodafternoonInterface::class, $taggedInterface->tag);
+        self::assertEqualsCanonicalizing([MoonClass::class, WorldClass::class], $taggedInterface->implementations);
+    }
+
+    public function test_it_can_tag_implementations_with_a_custom_tag_string(): void
+    {
+        $crawler = Crawler::in([SubjectDirectory::ALL]);
+        $electrician = new Electrician($crawler);
+
+        $taggedInterface = $electrician->tag(GoodeveningInterface::class);
+
+        self::assertEquals('evening', $taggedInterface->tag);
+        self::assertEqualsCanonicalizing([MarsClass::class, WorldClass::class], $taggedInterface->implementations);
     }
 
     public function test_it_can_connect_implementation(): void
@@ -125,6 +161,25 @@ final class ElectricianTest extends TestCase
         $electrician->configure(GoodbyeInterface::class);
     }
 
+    public function test_it_throws_exception_when_interface_can_not_be_tagged(): void
+    {
+        $crawler = Crawler::in([SubjectDirectory::CONTRACTS]);
+        $electrician = new Electrician($crawler);
+
+        $this->expectException(FaultyWiringException::class);
+        $this->expectExceptionMessage('No JeroenG\Autowire\Attribute\Autotag found in '.GoodbyeInterface::class);
+        $electrician->tag(GoodbyeInterface::class);
+    }
+
+    public function test_it_can_tell_if_class_has_custom_autotag_attribute(): void
+    {
+        $crawler = Crawler::in([SubjectDirectory::ALL]);
+        $electrician = new Electrician($crawler, autotagAttribute: CustomAutotag::class);
+
+        self::assertTrue($electrician->canAutotag(GoodmorningInterface::class));
+        self::assertFalse($electrician->canAutotag(GoodafternoonInterface::class));
+    }
+
     public function test_it_can_tell_if_class_has_custom_autowire_attribute(): void
     {
         $crawler = Crawler::in([SubjectDirectory::ALL]);
@@ -132,6 +187,17 @@ final class ElectricianTest extends TestCase
 
         self::assertTrue($electrician->canAutowire(HowDoYouDoInterface::class));
         self::assertFalse($electrician->canAutowire(HelloInterface::class));
+    }
+
+    public function test_it_can_tag_implementations_with_custom_autotag_attribute(): void
+    {
+        $crawler = Crawler::in([SubjectDirectory::ALL]);
+        $electrician = new Electrician($crawler, autotagAttribute: CustomAutotag::class);
+
+        $taggedInterface = $electrician->tag(GoodmorningInterface::class);
+
+        self::assertEquals(GoodmorningInterface::class, $taggedInterface->tag);
+        self::assertEqualsCanonicalizing([MarsClass::class, MoonClass::class], $taggedInterface->implementations);
     }
 
     public function test_it_can_connect_implementation_with_custom_autowire_attribute(): void
@@ -143,6 +209,17 @@ final class ElectricianTest extends TestCase
 
         self::assertEquals(HowDoYouDoInterface::class, $wire->interface);
         self::assertEquals(MoonClass::class, $wire->implementation);
+    }
+
+    /** @dataProvider invalidAttributeProvider */
+    public function test_it_throws_an_exception_on_an_invalid_custom_autotag_attribute(string $invalidAttribute, string $message): void
+    {
+        $crawler = Crawler::in([SubjectDirectory::ALL]);
+
+        $this->expectException(InvalidAttributeException::class);
+        $this->expectExceptionMessage(sprintf($message, Autotag::class));
+
+        new Electrician(crawler: $crawler, autotagAttribute: $invalidAttribute);
     }
 
     /** @dataProvider invalidAttributeProvider */

--- a/tests/Unit/TaggedInterfaceTest.php
+++ b/tests/Unit/TaggedInterfaceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Unit;
+
+use JeroenG\Autowire\TaggedInterface;
+use PHPUnit\Framework\TestCase;
+
+final class TaggedInterfaceTest extends TestCase
+{
+    public function test_tag_cannot_be_empty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Tag may not be empty');
+
+        new TaggedInterface('', []);
+    }
+    
+    public function test_all_implementations_must_be_valid_classes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Implementations must be valid classes');
+
+        new TaggedInterface('test', ['not_a_class']);
+    }
+    
+    public function test_an_exported_object_can_be_loaded(): void
+    {
+        $taggedInterface = TaggedInterface::__set_state([
+               'tag' => 'testTag',
+               'implementations' => [],
+        ]);
+        $this->assertEquals(new TaggedInterface('testTag', []), $taggedInterface);
+    }
+    
+    public function test_an_export_without_a_tag_cant_be_read(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid export');
+        
+        $taggedInterface = TaggedInterface::__set_state([
+               'implementations' => [],
+        ]);
+    }
+    
+    public function test_an_export_without_implementations_cant_be_read(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid export');
+        
+        $taggedInterface = TaggedInterface::__set_state([
+               'tag' => 'testTag',
+        ]);
+    }
+}


### PR DESCRIPTION
Hi there, 

This is a 'simple' addition of a new Attribute (and interface) that allows for instant tagging of all implementations of the interface the attribute is added to.

In the included implementation, the fully namespaced interface name is used as the tag name by default, but can be overridden by a string argument to the attribute.

The interface for the attribute specifies passing the `ReflectionClass` of the interface to the `getTag()` method, so that implementations can generate their tags in whatever way they desire.

I'm also working on an expansion of the `Configure` functionality to use tags, but once I'm happy with that, I'll submit it as a separate PR.