### PR TITLE
fix: Crawler should only return interfaces and non-abstract classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,10 @@
                 "JeroenG\\Autowire\\AutowireServiceProvider"
             ]
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "config": {
         "allow-plugins": {
-            "infection/extension-installer": true
+            "*": false
         }
     }
 }

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -6,6 +6,7 @@ namespace JeroenG\Autowire;
 
 use Ergebnis\Classy\Constructs;
 use Illuminate\Support\Collection;
+use ReflectionClass;
 
 final class Crawler
 {
@@ -19,6 +20,11 @@ final class Crawler
         $names = (new Collection($directories))
             ->map(fn(string $directory) => Constructs::fromDirectory($directory))
             ->flatten()
+            ->filter(function ($construct): bool {
+                $r = new ReflectionClass($construct->name());
+                
+                return $r->isInterface() || (!$r->isAbstract() && !$r->isTrait());
+            })
             ->map(fn($construct) => $construct->name());
 
         return new Crawler($names->toArray());

--- a/tests/Support/Subject/Domain/AbstractClass.php
+++ b/tests/Support/Subject/Domain/AbstractClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Subject\Domain;
+
+abstract class AbstractClass
+{        
+    public function howdy(): string
+    {
+        return 'howdy';
+    }
+}

--- a/tests/Support/Subject/Domain/PlanetTrait.php
+++ b/tests/Support/Subject/Domain/PlanetTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JeroenG\Autowire\Tests\Support\Subject\Domain;
+
+trait PlanetTrait
+{        
+    public function orbit(): void
+    {
+    }
+}


### PR DESCRIPTION
Right now, the `Crawler` will return any class-like file, including traits and abstract classes.

This means (for instance) if an abstract class implements an interface, and is the first file found by the `Electrician`, the plugin will try to inject the abstract class into the Service Provider.

As traits and abstract classes are basically never valid targets for autowiring or configuring, they should probably be filtered out.